### PR TITLE
fix: add /github/workspace as a safe directory

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -34,6 +34,7 @@ gh auth login --with-token <<< "${INPUT_GITHUB_TOKEN}"
 
 git config --global user.email "${INPUT_GIT_EMAIL:-73976634+loft-bot@users.noreply.github.com}" "noreply@loft.sh"
 git config --global user.name "${INPUT_GIT_USERNAME:-Loft Bot}" "Repo Sync Bot"
+git config --global --add safe.directory /github/workspace
 
 SOURCE_REPO_DIR=$PWD
 TARGET_REPO_DIR=$(mktemp -d)


### PR DESCRIPTION
unsure how to test this one safely, but from error output in the last sync failure this looks like it should sort things. I assume it is safe to add the directory to the "safe" list since we wouldn't be running this action unless we were merging and happy with what we are merging.